### PR TITLE
Fix Header export

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,3 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
-# garcommatch

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -278,4 +278,4 @@ const Header = () => {
   );
 };
 
-export default header;
+export default Header;


### PR DESCRIPTION
## Summary
- fix Header component export default
- clean up stray line in README

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684262c31998832eb9e7f52b3e81cb94